### PR TITLE
PR: `Auth` 레이어 분리(`Service`, `DAO`)

### DIFF
--- a/src/interfaces/auth/kakao-login.interface.ts
+++ b/src/interfaces/auth/kakao-login.interface.ts
@@ -4,6 +4,10 @@ export interface KakaoLogin {
   accessToken: string | Promise<string>;
 }
 
+export interface RequestUserInfoToKaKao {
+  userInfo: UserInfo;
+}
+
 interface UserInfo {
   id: number;
   connected_at: string;
@@ -24,13 +28,7 @@ interface UserInfo {
   };
 }
 
-export interface RequestUserInfoToKaKao {
-  isNewUser: boolean;
-  data?: object;
-  userInfo?: UserInfo;
-}
-
-export interface FindOneUserInfo {
+export interface SelectOneUser {
   id: number;
   createdAt: Date;
   updatedAt: Date;
@@ -43,4 +41,9 @@ export interface FindOneUserInfo {
   OAuthAccessToken: string;
   refreshToken: string;
   accessToken: string;
+}
+
+export interface SelectOneUserWithStatus {
+  data: SelectOneUser;
+  isNewUser: boolean;
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -11,8 +11,17 @@ import { KakaoLogin } from 'src/interfaces/auth/kakao-login.interface';
 export class AuthController {
   constructor(private readonly authService: AuthService, private readonly configService: ConfigService) {}
 
+  @Get('/kakao')
+  async getAuthrization(@Res() res) {
+    const url = `https://kauth.kakao.com/oauth/authorize?client_id=${this.configService.get(
+      'KAKAO_REST_API_KEY',
+    )}&redirect_uri=${this.configService.get('KAKAO_REDIRECT_URI')}&response_type=code`;
+    return res.redirect(302, url); // 1-1. 인가코드 발급을 위해 redirect_uri로 리다이렉트
+  }
+
   // 프론트에서 발급 받은 인가코드로 카카오에 토큰 발급 요청
-  @Post('/kakaoLogin')
+  // @Post('/kakaoLogin')
+  @Get('/kakaoLogin')
   async kakaoLogin(
     @Query() query,
     @Res({ passthrough: true }) res: Response,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -11,17 +11,8 @@ import { KakaoLogin } from 'src/interfaces/auth/kakao-login.interface';
 export class AuthController {
   constructor(private readonly authService: AuthService, private readonly configService: ConfigService) {}
 
-  @Get('/kakao')
-  async getAuthrization(@Res() res) {
-    const url = `https://kauth.kakao.com/oauth/authorize?client_id=${this.configService.get(
-      'KAKAO_REST_API_KEY',
-    )}&redirect_uri=${this.configService.get('KAKAO_REDIRECT_URI')}&response_type=code`;
-    return res.redirect(302, url); // 1-1. 인가코드 발급을 위해 redirect_uri로 리다이렉트
-  }
-
   // 프론트에서 발급 받은 인가코드로 카카오에 토큰 발급 요청
-  // @Post('/kakaoLogin')
-  @Get('/kakaoLogin')
+  @Post('/kakaoLogin')
   async kakaoLogin(
     @Query() query,
     @Res({ passthrough: true }) res: Response,

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { User } from '@entities/user.entity';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtProvider } from 'src/providers/jwt/jwt.provider';
+import { KakaoProvider } from 'src/providers/kakao/kakao.provider';
 
 @Module({
   imports: [
@@ -20,6 +21,6 @@ import { JwtProvider } from 'src/providers/jwt/jwt.provider';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, AuthDAO, JwtProvider],
+  providers: [AuthService, AuthDAO, JwtProvider, KakaoProvider],
 })
 export class AuthModule {}

--- a/src/modules/auth/dao/auth.dao.ts
+++ b/src/modules/auth/dao/auth.dao.ts
@@ -1,33 +1,33 @@
 import { User } from '@entities/user.entity';
-import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
+import { SelectOneUser } from 'src/interfaces/auth/kakao-login.interface';
 import { Repository } from 'typeorm';
 
 export class AuthDAO {
-  constructor(
-    @InjectRepository(User) private readonly userRepository: Repository<User>,
-    private readonly configService: ConfigService,
-  ) {}
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
 
-  async selectOneUserBySocialId(socialId) {
-    const selectOneUserBySocialId = await this.userRepository.findOne({ where: { socialId } });
-    const isNewUser = !selectOneUserBySocialId ? true : false;
-
-    return { data: selectOneUserBySocialId, isNewUser };
+  async selectOneUserBySocialId(socialId): Promise<SelectOneUser> {
+    return await this.userRepository.findOne({ where: { socialId } });
   }
 
   async createUser(userInfo, kakaoTokens) {
-    const createUser = await this.userRepository.save({
-      socialId: userInfo.id,
-      socialType: 'KAKAO',
-      nickname: userInfo.properties.nickname,
-      profileImage: userInfo.properties.profile_image,
-      OAuthRefreshToken: kakaoTokens.refreshToken,
-      OAuthAccessToken: kakaoTokens.accessToken,
-    });
+    const createUser = await this.userRepository
+      .createQueryBuilder()
+      .insert()
+      .into(User)
+      .values([
+        {
+          socialId: userInfo.id,
+          socialType: 'KAKAO',
+          nickname: userInfo.properties.nickname,
+          profileImage: userInfo.properties.profile_image,
+          OAuthRefreshToken: kakaoTokens.refreshToken,
+          OAuthAccessToken: kakaoTokens.accessToken,
+        },
+      ])
+      .execute();
 
-    const { id } = createUser;
-
+    const id = createUser.raw.insertId;
     return { id };
   }
 
@@ -53,58 +53,4 @@ export class AuthDAO {
       .where(id)
       .execute();
   }
-
-  // async kakaoSignIn(kakaoTokens, userInfo) {
-  //   const socialId = userInfo.id;
-  //   const { nickname } = userInfo.properties;
-  //   const profileImage = userInfo.properties.profile_image;
-  //   const [kakaoRefreshToken, kakaoAccessToken] = [kakaoTokens.access_token, kakaoTokens.refresh_token];
-
-  //   // 신규 회원 유무 판단
-  //   const checkThisUser = await this.userRepository.findOne({ where: { socialId } });
-  //   const isNewUser = !checkThisUser; // checkThisUser가 없으면 true, 있으면 false
-
-  //   let result = '';
-  //   // 이미 존재하는 회원이면
-  //   // 유저의 액세스 토큰 만료 기간 확인
-  //   if (!isNewUser) {
-  //     // DB에서 액세스 토큰 찾기
-  //     // 액세스 토큰의 만료시간 확인
-  //     // 만료시간이 안 지났으면 해당 토큰과 리프레쉬 토큰 반환하기
-  //     // 만료시간이 지났으면 새로 액세스 토큰 만들어서 프레쉬 토큰 반환하기
-  //   } else {
-  //     // 액세스 토큰 페이로드 값 세팅(추가)
-  //     const userPayload = {
-  //       id: isNewUser ? null : checkThisUser.id,
-  //       nickname: isNewUser ? nickname : checkThisUser.nickname,
-  //       profileImage: isNewUser ? profileImage : checkThisUser.profileImage,
-  //     };
-
-  //     // 리프레쉬 토큰
-  //     const refreshToken = this.generateRefreshToken(userPayload);
-  //     const accessToken = this.generateAccessToken(userPayload);
-
-  //     // 신규 회원일 경우 create(추가)
-  //     // DB에 토큰 저장
-  //     const createUser = await this.userRepository.save({
-  //       socialId,
-  //       socialType: 'KAKAO',
-  //       OAuthRefreshToken: kakaoRefreshToken,
-  //       OAuthAccessToken: kakaoAccessToken,
-  //       AppRefreshToken: refreshToken,
-  //       AppAccessToken: accessToken,
-  //       ...userPayload,
-  //     });
-  //     userPayload.id = createUser.id;
-
-  //     result = { refreshToken, accessToken };
-  //     return result;
-  //   }
-
-  //   // 원래 기존에 가입한 회원이어도 리프레쉬 토큰이 풀려서 다시 로그인하게 된다면 리프레쉬 토큰을 재발급한다.
-  //   return {
-  //     refreshToken: result.refreshToken,
-  //     accessToken: result.accessToken,
-  //   };
-  // }
 }

--- a/src/providers/kakao/kakao.provider.ts
+++ b/src/providers/kakao/kakao.provider.ts
@@ -1,0 +1,42 @@
+import { KakaoTokensParam } from '@auth/dto/param/kakaoTokens.param';
+import { KakaoLoginRequestDto } from '@auth/dto/request/kakao-login.req.dto';
+import { Injectable } from '@nestjs/common';
+import * as querystring from 'querystring';
+import axios from 'axios';
+import { RequestUserInfoToKaKao } from 'src/interfaces/auth/kakao-login.interface';
+
+@Injectable()
+export class KakaoProvider {
+  /** 카카오 토큰 요청 */
+  async requestTokensToKakao(kakaoLoginRequestDto: KakaoLoginRequestDto): Promise<{ kakaoTokens: KakaoTokensParam }> {
+    const urlToRequest = 'https://kauth.kakao.com/oauth/token';
+    const headers = {
+      'Content-type': `application/x-www-form-urlencoded;charset=utf-8`,
+    };
+    const body = querystring.stringify({
+      // header의 해당 Content-Type으로 인해
+      grant_type: 'authorization_code',
+      client_id: kakaoLoginRequestDto.apiKey,
+      redirect_uri: kakaoLoginRequestDto.redirectUri,
+      code: kakaoLoginRequestDto.code,
+    });
+
+    const response = await axios.post(urlToRequest, body, { headers });
+    const kakaoTokens: KakaoTokensParam = {
+      refreshToken: response.data.refresh_token,
+      accessToken: response.data.access_token,
+    };
+
+    return { kakaoTokens };
+  }
+
+  /** 카카오 회원 정보 요청 */
+  async requestUserInfoToKakao(kakaoTokens): Promise<RequestUserInfoToKaKao> {
+    const getUserInfo = await axios.get('https://kapi.kakao.com/v2/user/me', {
+      headers: { Authorization: `Bearer ${kakaoTokens.accessToken}` },
+    });
+    const userInfo = getUserInfo.data; // 발급한 토큰 정보
+
+    return { userInfo };
+  }
+}


### PR DESCRIPTION
### Summary
- `Auth` 레이어 분리(`Service`, `DAO`)

### Describe your changes
- `kakao provider` 생성하여 서비스 레이어에서 분리
- `auth.dao`에서 일부 서비스 로직 포함되었던 부분 서비스 레이어로 분리

### Issue number with link
- #10 